### PR TITLE
LIMS-2695

### DIFF
--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.4.0 (unreleased)
 ------------------
 
+- LIMS-2695: Improve performance of worksheet results (manage_analyses) view
 - Saving '-----' and negetive values as 0(Only for Shimadzu instruments)
 - Issue-2183: Don't recalculate prices when option "Include and display pricing information" in Bika Setup Accounting is not selected
 - Sampler and Sampling Date Columns are not validated when they are not displayed


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

https://jira.bikalabs.com/browse/LIMS-2695

## Current behavior before PR

Very slow to view worksheet manage_results

## Desired behavior after PR is merged

Manage results on a worksheet such as those used in the BC test2 instance are viewable in acceptable times.

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
